### PR TITLE
Move data fetching into `FlightCard`

### DIFF
--- a/app/action.tsx
+++ b/app/action.tsx
@@ -31,6 +31,8 @@ interface UIStateItem {
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
 async function getFlightInfo(flightNumber: string): Promise<FlightInfo> {
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
   return {
     flightNumber,
     departure: "New York",

--- a/app/action.tsx
+++ b/app/action.tsx
@@ -1,6 +1,7 @@
 import { OpenAI } from "openai";
 import { createAI, getMutableAIState, render } from "ai/rsc";
 import { z } from "zod";
+import { Suspense } from "react";
 
 interface FlightInfo {
   readonly flightNumber: string;
@@ -31,13 +32,17 @@ interface UIStateItem {
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
 async function getFlightInfo(flightNumber: string): Promise<FlightInfo> {
-  await new Promise((resolve) => setTimeout(resolve, 100));
+  await new Promise((resolve) => setTimeout(resolve, 500));
 
   return {
     flightNumber,
     departure: "New York",
     arrival: "San Francisco",
   };
+}
+
+function Spinner() {
+  return <div>Loading...</div>;
 }
 
 async function FlightCard({ flightNumber }: FlightCardProps) {
@@ -93,7 +98,11 @@ async function submitUserMessage(userInput: string): Promise<UIStateItem> {
             },
           ]);
 
-          return <FlightCard flightNumber={flightNumber} />;
+          return (
+            <Suspense fallback={<Spinner />}>
+              <FlightCard flightNumber={flightNumber} />
+            </Suspense>
+          );
         },
       },
     },

--- a/app/action.tsx
+++ b/app/action.tsx
@@ -9,7 +9,7 @@ interface FlightInfo {
 }
 
 interface FlightCardProps {
-  readonly flightInfo: FlightInfo;
+  readonly flightNumber: string;
 }
 
 type AIStateItem =
@@ -38,11 +38,9 @@ async function getFlightInfo(flightNumber: string): Promise<FlightInfo> {
   };
 }
 
-function Spinner() {
-  return <div>Loading...</div>;
-}
+async function FlightCard({ flightNumber }: FlightCardProps) {
+  const flightInfo = await getFlightInfo(flightNumber);
 
-function FlightCard({ flightInfo }: FlightCardProps) {
   return (
     <div>
       <h2>Flight Information</h2>
@@ -83,21 +81,17 @@ async function submitUserMessage(userInput: string): Promise<UIStateItem> {
             flightNumber: z.string().describe("the number of the flight"),
           })
           .required(),
-        render: async function* ({ flightNumber }) {
-          yield <Spinner />;
-
-          const flightInfo = await getFlightInfo(flightNumber);
-
+        render: function ({ flightNumber }) {
           aiState.done([
             ...aiState.get(),
             {
               role: "function",
               name: "get_flight_info",
-              content: JSON.stringify(flightInfo),
+              content: "TODO",
             },
           ]);
 
-          return <FlightCard flightInfo={flightInfo} />;
+          return <FlightCard flightNumber={flightNumber} />;
         },
       },
     },


### PR DESCRIPTION
## How we got here (commits on `main`)

- [Initial commit from Create Next App](https://github.com/unstubbable/ai-rsc-test/commit/e41923f6bacdedf64e60b04bf55f2a00902fe3da)
- [Remove default content from page](https://github.com/unstubbable/ai-rsc-test/commit/3866987c13a460c41b7eedcbdd26d01453036d4a)
- [Copy ai/rsc example from docs](https://github.com/unstubbable/ai-rsc-test/commit/ef44eb040b8afaee86a6b7c3665f19983748998d) (i.e. https://sdk.vercel.ai/docs/concepts/ai-rsc#build-your-app)

## Reproducing the issue (this PR)

When moving the data fetching from `render` into the `FlightCard` component, a race condition is triggered where, under certain circumstances, e.g. when starting the server with a production build, or when delaying the data fetching, the rendered element is unmounted again.

Here's how it should behave:

https://github.com/unstubbable/ai-rsc-test/assets/761683/6db70542-c887-4aeb-89ba-ac5b2c7b2579

And here it's failing:

https://github.com/unstubbable/ai-rsc-test/assets/761683/ca6a2f79-adc9-41f3-b551-88f4c1b1ea87

This is the RSC response for the successful run:

```
0:["$@1",["development",null]]
3:"$Sreact.suspense"
4:D{"name":"","env":"Server"}
1:["$@2",{"id":1710917980696,"display":["$","$3",null,{"fallback":"$undefined","children":"$L4"}]}]
2:{"0":[{"role":"user","content":"flight 42"}],"1":[{"role":"function","name":"get_flight_info","content":"TODO"}],"_t":"a"}
5:D{"name":"FlightCard","env":"Server"}
6:D{"name":"","env":"Server"}
4:["$","$3",null,{"fallback":"$L5","children":"$L6"}]
5:["$","div",null,{"children":[["$","h2",null,{"children":"Flight Information"}],["$","p",null,{"children":["Flight Number: ","42"]}],["$","p",null,{"children":["Departure: ","New York"]}],["$","p",null,{"children":["Arrival: ","San Francisco"]}]]}]
6:"$5"
```

And this is the RSC response for the failed run:

```
0:["$@1",["development",null]]
3:"$Sreact.suspense"
4:D{"name":"","env":"Server"}
1:["$@2",{"id":1710918908284,"display":["$","$3",null,{"fallback":"$undefined","children":"$L4"}]}]
2:{"0":[{"role":"user","content":"flight 42"}],"1":[{"role":"function","name":"get_flight_info","content":"TODO"}],"_t":"a"}
5:D{"name":"FlightCard","env":"Server"}
6:D{"name":"","env":"Server"}
4:["$","$3",null,{"fallback":"$L5","children":"$L6"}]
6:"$5"
5:["$","div",null,{"children":[["$","h2",null,{"children":"Flight Information"}],["$","p",null,{"children":["Flight Number: ","42"]}],["$","p",null,{"children":["Departure: ","New York"]}],["$","p",null,{"children":["Arrival: ","San Francisco"]}]]}]
```

Note that the last two RSC rows are switched here. When I add a breakpoint to `setMessages`, or delay the setter with a timeout, this response is also handled correctly, though.